### PR TITLE
Update the Discord invite links to resolve #7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ The following is a set of rules and guidelines for contributing to this repo. Pl
 ## Submitting issues
 
 If you have questions about how to use Casper Account Info Contract, please direct these to the related discord channels:
-* [#validators-general](https://discord.gg/S398hSJS)
-* [#node-tech-support](https://discord.gg/8urw83VN)
-* [#casperdotlive](https://discord.gg/eW8yfJvu)
+* [#validators-general](https://discord.gg/9CTHRvvA4d)
+* [#node-tech-support](https://discord.gg/9CTHRvvA4d)
+* [#casperdotlive](https://discord.gg/9CTHRvvA4d)
 
 ### Guidelines
 * Please search the existing issues first, it's likely that your issue was already reported or even fixed.


### PR DESCRIPTION
They now have no expiry date. The 3 links are the same on purpose
because the channels are not visible on first visit.


* Resolves: #7 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required

