### PR TITLE
Fix the public-key param

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ casper-client get-dictionary-item \
   --node-address http://$NODE_ADDRESS:7777 \
   --state-root-hash "$STATE_ROOT_HASH" \
   --seed-uref  "$ACCOUNT_INFO_URLS_DICT_UREF" \
-  --dictionary-item-key "$(casper-client account-address -public-key $PUBLIC_KEY | sed -r 's/account-hash-//g')"
+  --dictionary-item-key "$(casper-client account-address --public-key $PUBLIC_KEY | sed -r 's/account-hash-//g')"
 ```
 
 ##### Using the ```tools/get-account-info-url.sh``` and ```tools/get-account-info.sh``` scripts
@@ -197,7 +197,7 @@ casper-client put-deploy \
     --session-hash "$ACCOUNT_INFO_CONTRACT_HASH" \
     --session-entry-point "set_url_for_account" \
     --payment-amount 500000000 \
-    --session-arg=account:"account_hash='$(casper-client account-address -public-key $PUBLIC_KEY)'" \
+    --session-arg=account:"account_hash='$(casper-client account-address --public-key $PUBLIC_KEY)'" \
     --session-arg=url:"string='https://casper-account-info-example.make.services'"
 ```
 
@@ -249,7 +249,7 @@ casper-client put-deploy \
     --session-hash "$ACCOUNT_INFO_CONTRACT_HASH" \
     --session-entry-point "disable_admin" \
     --payment-amount 500000000 \
-    --session-arg=account:"account_hash='$(casper-client account-address -public-key $PUBLIC_KEY)'"
+    --session-arg=account:"account_hash='$(casper-client account-address --public-key $PUBLIC_KEY)'"
 ```
 
 #### Set amount of CSPR to burn during the first ```set_url``` call
@@ -296,7 +296,7 @@ casper-client get-dictionary-item \
   --node-address http://$NODE_ADDRESS:7777 \
   --state-root-hash "$STATE_ROOT_HASH" \
   --seed-uref  "$ACCOUNT_INFO_ADMINS_DICT_UREF" \
-  --dictionary-item-key "$(casper-client account-address -public-key $PUBLIC_KEY | sed -r 's/account-hash-//g')"
+  --dictionary-item-key "$(casper-client account-address --public-key $PUBLIC_KEY | sed -r 's/account-hash-//g')"
 ```
 
 ##### Using the ```tools/is-admin.sh``` script


### PR DESCRIPTION
### Summary
It is documentation related issue and solved by updating -public-key argument with --public-key in the README.md file.

### TODO
 -public-key argument is corrected in the README.md file.

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included
- [x] Documentation (manuals or wiki) has been updated

![Screenshot from 2023-12-21 02-50-31](https://github.com/make-software/casper-account-info-contract/assets/18303197/52b60b8d-91e4-45b3-bf0d-0e8a23ff035d)
![Screenshot from 2023-12-21 02-55-03](https://github.com/make-software/casper-account-info-contract/assets/18303197/c0fa4973-d61f-4ceb-a848-e601fccb4a40)
